### PR TITLE
Enable support for binding to an instance of kendo.data.DataSource

### DIFF
--- a/src/knockout-kendo-core.js
+++ b/src/knockout-kendo-core.js
@@ -215,6 +215,11 @@ ko.kendo.bindingFactory = new ko.kendo.BindingFactory();
 
 //utility to set the dataSource with a clean copy of data. Could be overridden at run-time.
 ko.kendo.setDataSource = function(widget, data, options) {
+    if (data instanceof kendo.data.DataSource) {
+        widget.setDataSource(data);
+        return;
+    }
+    
     var isMapped, cleanData;
 
     if (!options || !options.useKOTemplates) {


### PR DESCRIPTION
I needed the ability to bind directly to my own instance of a kendo.data.DataSource. This small change enabled this for me, and I am submitting to you for consideration.
