### PR TITLE
Fixed kendoTreeItem binding to allow initial selection

### DIFF
--- a/src/knockout-kendoTreeView.js
+++ b/src/knockout-kendoTreeView.js
@@ -10,7 +10,11 @@ createBinding({
         enabled: ENABLE,
         expanded: [EXPAND, COLLAPSE],
         selected: function(element, value) {
-            this.select(value ? element : null);
+            if (value) {
+                this.select(element);
+            } else if (this.select()[0] == element) {
+                this.select(null);
+            }
         }
     },
     childProp: "node",


### PR DESCRIPTION
Tree items could not be initially selected. When the binding processes an item with `this.selected() == true` , it selects an item, but when it processes following items with `this.selected() == false`, it removes the selection.
I have fixed it, so tree items can be selected initially and deselected by calling `this.selected(false)` on the selected item.
