### PR TITLE
Update knockout-kendo-core.js

### DIFF
--- a/src/knockout-kendo-core.js
+++ b/src/knockout-kendo-core.js
@@ -189,7 +189,7 @@ ko.kendo.BindingFactory = function() {
                 }
             },
             disposeWhenNodeIsRemoved: element
-        }).extend({ throttle: 1 });
+        }).extend({ throttle: options.throttle ? options.throttle : 1 });
 
         //if option is not observable, then dispose up front after executing the logic once
         if (!ko.isObservable(options[prop])) {


### PR DESCRIPTION
Why should we always invoke async method calls if not wanted?
With this approach, we can decide if the widget should use async events or not.
e.g.
kendoGrid: { throttle: -1 }
If not specified, by default it will execute async calls.

Hope this helps.
