### PR TITLE
Allow Notification binding to accept an object to properly bind to Kendo...

### DIFF
--- a/src/knockout-kendoNotification.js
+++ b/src/knockout-kendoNotification.js
@@ -1,6 +1,17 @@
 var notificationHandler = function(type, value) {
     if (value || value === 0) {
-        this.show(value, type);
+		if (typeof value === "object") {
+			this.show(value, type);
+		}
+		else{
+			try{
+				this.show(JSON.parse(value), type);
+			}
+			catch(e) {
+				// JSON parsing probably failed.  Maybe just a plain string?
+				this.show(value, type);
+			}
+		}
     }
     else {
         this.hide();

--- a/src/knockout-kendoNotification.js
+++ b/src/knockout-kendoNotification.js
@@ -5,7 +5,7 @@ var notificationHandler = function(type, value) {
 		}
 		else{
 			try{
-				this.show(JSON.parse(value), type);
+				this.show($.parseJSON(value), type);
 			}
 			catch(e) {
 				// JSON parsing probably failed.  Maybe just a plain string?


### PR DESCRIPTION
... templates.

Fixes #165 

 Now we can accept a Javascript object or a string in JSON formatting to be parsed so that Kendo Templating of the notification still functions as expected.


Why: Previously we were only able to accept a simple string. This meant that the Kendo templates would fail to bind and the whole thing fails with a simple console error.

What: Allow the use of objects or strings in JSON formatting to also be used to populate a notification.

How: Determine if the object passed in is an object and, if so, use it.  If it is not an object, determine if it is JSON parsable.  If it is, parse it and use it.  If not, simply use the string as it was passed in (fallback to the previous implementation of simple string usage).