### PR TITLE
Fix documentation issue on the global options portion of TabStrip.

### DIFF
--- a/web/TabStrip.md
+++ b/web/TabStrip.md
@@ -60,7 +60,7 @@ examples:
       js: |
         var ViewModel = function() {};
         
-        ko.bindingHandlers.kendoTabStrip.animation = false;
+        ko.bindingHandlers.kendoTabStrip.options.animation = false;
       id: three
 liveOptions:
     - name: enabled


### PR DESCRIPTION
The TabStrip documentation had an incorrect line of JavaScript for dealing with the animation binding handler as it excluded the "options" property.