### PR TITLE
Fix for memory leak #250

### DIFF
--- a/spec/knockout-kendo-core.spec.js
+++ b/spec/knockout-kendo-core.spec.js
@@ -236,6 +236,15 @@ describe("knockout-kendo-core", function(){
                expect(widget.dataSource).toEqual(options.dataSource); //not touched
            });
 
+           it("should not pass the widget options to the kendo widget", function() {
+               var options = {
+                   observable: ko.observable("observable property"),
+                   widget: ko.observable(null)
+               };
+               setup(null, null, options);
+               expect(widget.widget).toBe(undefined);
+           })
+
         });
 
         describe("when widget is really on a parent", function() {

--- a/src/knockout-kendo-core.js
+++ b/src/knockout-kendo-core.js
@@ -140,17 +140,21 @@ ko.kendo.BindingFactory = function() {
     //return the actual widget
     this.getWidget = function(widgetConfig, options, $element) {
         var widget;
+        var unwrappedOptions = this.unwrapOneLevel(options);
+        var widgetOption = unwrappedOptions.widget;
+        delete unwrappedOptions.widget;
+        
         if (widgetConfig.parent) {
             //locate the actual widget
             var parent = $element.closest("[data-bind*='" + widgetConfig.parent + ":']");
             widget = parent.length ? parent.data(widgetConfig.parent) : null;
         } else {
-            widget = $element[widgetConfig.name](this.unwrapOneLevel(options)).data(widgetConfig.name);
+            widget = $element[widgetConfig.name](unwrappedOptions).data(widgetConfig.name);
         }
 
         //if the widget option was specified, then fill it with our widget
-        if (ko.isObservable(options.widget)) {
-            options.widget(widget);
+        if (ko.isObservable(widgetOption)) {
+            widgetOption(widget);
         }
 
         return widget;


### PR DESCRIPTION
options.widget shouldn't be passed to kendo in getWidget because kendo keeps a copy of the options, and repeated reinitialization of the widget will keep all previous instances of the widget